### PR TITLE
Enable aggressive optimization flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,11 @@ target_link_libraries(bfvmcpp PRIVATE
     Warnings
 )
 
+if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+    target_compile_options(bfvmcpp PRIVATE -O3 -march=native -flto)
+    target_link_options(bfvmcpp PRIVATE -flto)
+endif()
+
 find_program(CLANG_FORMAT_EXE NAMES clang-format)
 if(CLANG_FORMAT_EXE)
     add_custom_target(format


### PR DESCRIPTION
## Summary
- add -O3, -march=native and link-time optimization flags for GCC/Clang builds

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_6898493e60708331bb2ca5d99324f8ba