### PR TITLE
Improve file I/O and VM portability

### DIFF
--- a/main.cxx
+++ b/main.cxx
@@ -104,13 +104,20 @@ int main(int argc, char* argv[]) {
     if (help) {
         std::cout << "Usage: " << argv[0] << " [options]" << std::endl;
     } else if (!filename.empty()) {
-        std::ifstream in(filename);
-        if (std::string code; in.good()) {
-            code.assign(std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>());
-            executeExcept(cells, cellptr, code, optimize, eof, dynamicSize);
-            if (sdumpMemory) dumpMemory(cells, cellptr);
+        std::ifstream in(filename, std::ios::binary);
+        if (!in.is_open()) {
+            std::cout << fg::red << "ERROR:" << fg::reset
+                      << " File could not be opened";
         } else {
-            std::cout << fg::red << "ERROR:" << fg::reset << " File could not be read";
+            std::string code((std::istreambuf_iterator<char>(in)),
+                             std::istreambuf_iterator<char>());
+            if (!in && !in.eof()) {
+                std::cout << fg::red << "ERROR:" << fg::reset
+                          << " Error while reading file";
+            } else {
+                executeExcept(cells, cellptr, code, optimize, eof, dynamicSize);
+                if (sdumpMemory) dumpMemory(cells, cellptr);
+            }
         }
     } else {
         Term::terminal.setOptions(Term::Option::ClearScreen, Term::Option::NoSignalKeys,


### PR DESCRIPTION
## Summary
- verify program file opens and reads successfully before execution
- keep computed goto dispatch and add explicit casts to avoid narrowing
- fix dynamic memory expansion to avoid signed/unsigned comparison issues

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68985042c4908331acb5007bb0527097