### PR TITLE
Fix Windows workflow artifact path

### DIFF
--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -23,43 +23,42 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Setup MSYS2 (Windows)
-      if: runner.os == 'Windows'
-      uses: msys2/setup-msys2@v2
-      with:
-        msystem: MINGW64
-        install: |
-          mingw-w64-x86_64-gcc
-          mingw-w64-x86_64-cmake
-          mingw-w64-x86_64-make
-        path-type: inherit
+      - name: Setup MSYS2 (Windows)
+        if: runner.os == 'Windows'
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          install: |
+            mingw-w64-x86_64-gcc
+            mingw-w64-x86_64-cmake
+            mingw-w64-x86_64-make
+          path-type: inherit
 
-    - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_C_COMPILER=${{env.CC}} -DCMAKE_CXX_COMPILER=${{env.CXX}} ${{ runner.os == 'Windows' && '-G "MinGW Makefiles"' || '' }}
-      shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
+      - name: Configure CMake
+        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_C_COMPILER=${{env.CC}} -DCMAKE_CXX_COMPILER=${{env.CXX}} ${{ runner.os == 'Windows' && '-G "MinGW Makefiles"' || '' }}
+        shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
 
-    - name: Build
-      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
-      shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
+      - name: Build
+        run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+        shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
 
-    - name: Test
-      working-directory: ${{github.workspace}}/build
-      run: ctest -C ${{env.BUILD_TYPE}}
-      shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
+      - name: Test
+        working-directory: ${{github.workspace}}/build
+        run: ctest -C ${{env.BUILD_TYPE}}
+        shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
 
-    - name: Upload Linux artifact
-      if: runner.os == 'Linux'
-      uses: actions/upload-artifact@v4
-      with:
-        name: bfvmcpp-linux
-        path: build/bfvmcpp
+      - name: Upload Linux artifact
+        if: runner.os == 'Linux'
+        uses: actions/upload-artifact@v4
+        with:
+          name: bfvmcpp-linux
+          path: build/bfvmcpp
 
-    - name: Upload Windows artifact
-      if: runner.os == 'Windows'
-      uses: actions/upload-artifact@v4
-      with:
-        name: bfvmcpp-windows
-        path: build/${{ env.BUILD_TYPE }}/bfvmcpp.exe
-
+      - name: Upload Windows artifact
+        if: runner.os == 'Windows'
+        uses: actions/upload-artifact@v4
+        with:
+          name: bfvmcpp-windows
+          path: build/bfvmcpp.exe


### PR DESCRIPTION
## Summary
- fix Windows artifact path in GitHub Actions workflow
- tidy workflow indentation

## Testing
- `cmake --build build --config Release`
- `ctest -C Release`
- `yamllint -d '{extends: default, rules: {line-length: {max: 200, level: warning}, document-start: disable, truthy: disable, brackets: disable, empty-lines: {max: 1}}}' .github/workflows/cmake-single-platform.yml`


------
https://chatgpt.com/codex/tasks/task_e_68989405990083318c536fa425b8b90a