### PR TITLE
fix: ensure TUI renders correctly on Windows

### DIFF
--- a/src/repl.cpp
+++ b/src/repl.cpp
@@ -54,7 +54,7 @@ std::string render(Term::Window& scr, const std::vector<std::string>& log, const
     scr.print_str(1, rows, status);
 
     scr.set_cursor_pos(std::min(prompt.size() + 1, cols), rows - 1);
-    return scr.render(1, 1, false);
+    return scr.render(1, 1, true);
 }
 }  // namespace
 


### PR DESCRIPTION
## Summary
- render REPL window using terminal-aware mode to keep screen updates consistent on Windows

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest` *(fails: No test configuration file found!)*

------
https://chatgpt.com/codex/tasks/task_e_6898a10a6fcc8331ba18b0963118d149