### PR TITLE
chore: adopt cxx/hxx extensions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,10 +20,10 @@ add_subdirectory(regex-develop)
 
 set(PROJECT_SOURCES
     main.cxx
-    src/vm.cpp
-    include/vm.hpp
-    src/repl.cpp
-    include/repl.hpp
+    src/vm.cxx
+    include/vm.hxx
+    src/repl.cxx
+    include/repl.hxx
 )
 
 add_executable(bfvmcpp

--- a/include/repl.hxx
+++ b/include/repl.hxx
@@ -1,3 +1,9 @@
+/*
+    Goof - An optimizing brainfuck VM
+    REPL API declarations
+    Published under the GNU AGPL-3.0-or-later license
+*/
+// SPDX-License-Identifier: AGPL-3.0-or-later
 #pragma once
 #include <cstdint>
 #include <iostream>

--- a/include/vm.hxx
+++ b/include/vm.hxx
@@ -1,3 +1,9 @@
+/*
+    Goof - An optimizing brainfuck VM
+    VM API declarations
+    Published under the GNU AGPL-3.0-or-later license
+*/
+// SPDX-License-Identifier: AGPL-3.0-or-later
 #pragma once
 #define BFVMCPP_DEFAULT_EOF_BEHAVIOUR 0
 #define BFVMCPP_DYNAMIC_CELLS_SIZE 1

--- a/main.cxx
+++ b/main.cxx
@@ -17,10 +17,10 @@
 #include <vector>
 
 #include "argh.hxx"
-#include "include/vm.hpp"
+#include "include/vm.hxx"
 #include "cpp-terminal/color.hpp"
 #include "cpp-terminal/style.hpp"
-#include "repl.hpp"
+#include "repl.hxx"
 
 void dumpMemory(const std::vector<uint8_t>& cells, size_t cellptr, std::ostream& out) {
     if (cells.empty()) {

--- a/src/repl.cxx
+++ b/src/repl.cxx
@@ -4,7 +4,7 @@
     Published under the GNU AGPL-3.0-or-later license
 */
 // SPDX-License-Identifier: AGPL-3.0-or-later
-#include "repl.hpp"
+#include "repl.hxx"
 
 #include <algorithm>
 #include <sstream>
@@ -19,7 +19,7 @@
 #include "cpp-terminal/terminal.hpp"
 #include "cpp-terminal/window.hpp"
 #include "cpp-terminal/terminfo.hpp"
-#include "include/vm.hpp"
+#include "include/vm.hxx"
 
 namespace {
 bool supports_color() {

--- a/src/vm.cxx
+++ b/src/vm.cxx
@@ -1,4 +1,10 @@
-#include "vm.hpp"
+/*
+    Goof - An optimizing brainfuck VM
+    VM implementation
+    Published under the GNU AGPL-3.0-or-later license
+*/
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#include "vm.hxx"
 
 #include <algorithm>
 #include <array>


### PR DESCRIPTION
## Summary
- add project info and license headers to vm sources and public headers
- rename project sources/headers to `.cxx`/`.hxx` and update includes and build script

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_6899ca7cf84483318cc992723cc8a244