### PR TITLE
Enable Windows VT processing and document platform support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,19 @@ cmake --build build
 
 The resulting executable will be located in the `build` directory.
 
+### Windows
+
+The project can also be built on Windows using CMake with either the
+MSVC or MinGW toolchains:
+
+```powershell
+cmake -S . -B build
+cmake --build build --config Release
+```
+
+ANSI escape sequences are enabled automatically on startup so colored
+output works in both PowerShell and `cmd.exe`.
+
 ## Usage
 
 The VM supports selectable cell widths. Use the `--cw` option to choose 8-, 16- or 32-bit

--- a/main.cxx
+++ b/main.cxx
@@ -22,7 +22,23 @@
 #include "cpp-terminal/style.hpp"
 #include "repl.hxx"
 
+#ifdef _WIN32
+#include <windows.h>
+// Enable ANSI escape sequences on Windows terminals
+static void enable_vt_mode() {
+    HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
+    if (hOut == INVALID_HANDLE_VALUE) return;
+    DWORD mode = 0;
+    if (!GetConsoleMode(hOut, &mode)) return;
+    mode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+    SetConsoleMode(hOut, mode);
+}
+#endif
+
 int main(int argc, char* argv[]) {
+#ifdef _WIN32
+    enable_vt_mode();
+#endif
     argh::parser cmdl(argc, argv, argh::parser::PREFER_PARAM_FOR_UNREG_OPTION);
 
     std::string filename;


### PR DESCRIPTION
## Summary
- conditionally enable Windows Virtual Terminal mode for color output
- document Windows build and runtime notes

## Testing
- `cmake -S . -B build && cmake --build build`
- `cmake -S . -B build-windows -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_CXX_COMPILER=x86_64-w64-mingw32-g++ -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc && cmake --build build-windows`


------
https://chatgpt.com/codex/tasks/task_e_689a2aa4b4dc8331bf8ac74eba0c3934