### PR TITLE
Add execute unit tests and enable CTest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,3 +67,6 @@ if(CLANG_FORMAT_EXE)
         COMMENT "Format source files"
     )
 endif()
+
+enable_testing()
+add_subdirectory(tests)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,33 @@
+add_executable(vm_execute_tests
+    ${CMAKE_SOURCE_DIR}/src/vm.cxx
+    test_execute.cxx
+)
+
+target_include_directories(vm_execute_tests PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_SOURCE_DIR}
+)
+
+target_link_libraries(vm_execute_tests PRIVATE
+    Boost::regex
+    cpp-terminal::cpp-terminal
+    Warnings
+)
+
+add_test(NAME vm_execute_tests COMMAND vm_execute_tests)
+
+add_executable(vm_execute_fuzz
+    ${CMAKE_SOURCE_DIR}/src/vm.cxx
+    fuzz_execute.cxx
+)
+
+target_include_directories(vm_execute_fuzz PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_SOURCE_DIR}
+)
+
+target_link_libraries(vm_execute_fuzz PRIVATE
+    Boost::regex
+    cpp-terminal::cpp-terminal
+    Warnings
+)

--- a/tests/fuzz_execute.cxx
+++ b/tests/fuzz_execute.cxx
@@ -1,0 +1,70 @@
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
+#include <random>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "vm.hxx"
+
+static std::string random_program(std::mt19937 &gen) {
+    static const char ops[] = "+-<>.,";
+    std::uniform_int_distribution<int> lenDist(0, 16);
+    std::uniform_int_distribution<int> opDist(0, sizeof(ops) - 2);
+    int len = lenDist(gen);
+    std::string program;
+    program.reserve(len);
+    int ptr = 0;
+    for (int i = 0; i < len; ++i) {
+        char op = ops[opDist(gen)];
+        if (op == '>' && ptr >= 31) {
+            --i;
+            continue;
+        }
+        if (op == '<' && ptr <= 0) {
+            --i;
+            continue;
+        }
+        program += op;
+        if (op == '>')
+            ++ptr;
+        else if (op == '<')
+            --ptr;
+    }
+    return program;
+}
+
+static std::string random_input(std::mt19937 &gen) {
+    std::uniform_int_distribution<int> lenDist(0, 8);
+    std::uniform_int_distribution<int> byteDist(0, 255);
+    int len = lenDist(gen);
+    std::string input;
+    input.reserve(len);
+    for (int i = 0; i < len; ++i) {
+        input += static_cast<char>(byteDist(gen));
+    }
+    return input;
+}
+
+int main() {
+    std::mt19937 gen(std::random_device{}());
+    for (int i = 0; i < 100; ++i) {
+        std::string code = random_program(gen);
+        std::string input = random_input(gen);
+        std::vector<uint8_t> cells(32, 0);
+        size_t ptr = 0;
+        std::istringstream in(input);
+        std::ostringstream out;
+        auto *cinbuf = std::cin.rdbuf(in.rdbuf());
+        auto *coutbuf = std::cout.rdbuf(out.rdbuf());
+        std::cin.clear();
+        try {
+            bfvmcpp::execute<uint8_t>(cells, ptr, code, true, 0, true, false);
+        } catch (...) {
+        }
+        std::cin.rdbuf(cinbuf);
+        std::cout.rdbuf(coutbuf);
+    }
+    return 0;
+}

--- a/tests/test_execute.cxx
+++ b/tests/test_execute.cxx
@@ -1,0 +1,65 @@
+#include "vm.hxx"
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+static std::string run(std::string code, std::vector<uint8_t>& cells, size_t& cellPtr,
+                       const std::string& input = "", int eof = 0) {
+    std::istringstream in(input);
+    std::ostringstream out;
+    auto* cinbuf = std::cin.rdbuf(in.rdbuf());
+    auto* coutbuf = std::cout.rdbuf(out.rdbuf());
+    std::cin.clear();
+    bfvmcpp::execute<uint8_t>(cells, cellPtr, code, true, eof, true, false);
+    std::cin.rdbuf(cinbuf);
+    std::cout.rdbuf(coutbuf);
+    return out.str();
+}
+
+static void test_loops() {
+    std::vector<uint8_t> cells(2, 0);
+    size_t ptr = 0;
+    run("++[>++<-]", cells, ptr);
+    assert(cells[0] == 0);
+    assert(cells[1] == 4);
+}
+
+static void test_io() {
+    std::vector<uint8_t> cells(1, 0);
+    size_t ptr = 0;
+    std::string out = run(",.", cells, ptr, "A");
+    assert(out == "A");
+    assert(cells[0] == static_cast<uint8_t>('A'));
+}
+
+static void test_wrapping() {
+    std::vector<uint8_t> cells(1, 0);
+    size_t ptr = 0;
+    run("-", cells, ptr);
+    assert(cells[0] == 255);
+}
+
+static void test_eof_behavior() {
+    std::vector<uint8_t> cells(1, 42);
+    size_t ptr = 0;
+    run(",", cells, ptr, "", 0);
+    assert(cells[0] == 42);
+    cells[0] = 42;
+    run(",", cells, ptr, "", 1);
+    assert(cells[0] == 0);
+    cells[0] = 42;
+    run(",", cells, ptr, "", 2);
+    assert(cells[0] == 255);
+}
+
+int main() {
+    test_loops();
+    test_io();
+    test_wrapping();
+    test_eof_behavior();
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add unit tests for the `execute` brainfuck VM covering loops, I/O, wrapping and EOF behavior
- enable CTest and hook up new tests in CMake
- add a fuzz harness generating random brainfuck programs

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cd build && ctest --output-on-failure`
- `./build/tests/vm_execute_fuzz`


------
https://chatgpt.com/codex/tasks/task_e_689a2a28de7083319801d59210157122