### PR TITLE
Add 64-bit cell width support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ option(BUILD_COVERAGE "Enable coverage reporting" OFF)
 if(BUILD_COVERAGE AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
     add_compile_options(--coverage -O0 -g)
     add_link_options(--coverage)
+endif()
 # Default to a Release build if no build type is explicitly set.  This keeps
 # binaries small and enables the high-optimization flags defined below.
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)

--- a/include/repl.hxx
+++ b/include/repl.hxx
@@ -69,3 +69,4 @@ inline void executeExcept(std::vector<CellT>& cells, size_t& cellPtr, std::strin
 extern template void runRepl<uint8_t>(std::vector<uint8_t>&, size_t&, size_t, bool, int, bool);
 extern template void runRepl<uint16_t>(std::vector<uint16_t>&, size_t&, size_t, bool, int, bool);
 extern template void runRepl<uint32_t>(std::vector<uint32_t>&, size_t&, size_t, bool, int, bool);
+extern template void runRepl<uint64_t>(std::vector<uint64_t>&, size_t&, size_t, bool, int, bool);

--- a/include/vm.hxx
+++ b/include/vm.hxx
@@ -16,7 +16,7 @@
 
 namespace bfvmcpp {
 /// @brief Only function you should use in your code. For now, it always prints to stdout.
-/// @tparam CellT Cell width type (uint8_t, uint16_t, uint32_t)
+/// @tparam CellT Cell width type (uint8_t, uint16_t, uint32_t, uint64_t)
 /// @param cells Vector of cells of type CellT.
 /// @param cellPtr
 /// @param code Remember that this will be modified, so if you need to do something else with your

--- a/main.cxx
+++ b/main.cxx
@@ -102,10 +102,13 @@ int main(int argc, char* argv[]) {
         case 32:
             run(uint32_t{});
             break;
+        case 64:
+            run(uint64_t{});
+            break;
         default:
             std::cout << Term::color_fg(Term::Color::Name::Red) << "ERROR:"
                       << Term::color_fg(Term::Color::Name::Default)
-                      << " Unsupported cell width; use 8,16,32" << std::endl;
+                      << " Unsupported cell width; use 8,16,32,64" << std::endl;
             return 1;
     }
 }

--- a/src/repl.cxx
+++ b/src/repl.cxx
@@ -192,3 +192,4 @@ void runRepl(std::vector<CellT>& cells, size_t& cellPtr, size_t ts, bool optimiz
 template void runRepl<uint8_t>(std::vector<uint8_t>&, size_t&, size_t, bool, int, bool);
 template void runRepl<uint16_t>(std::vector<uint16_t>&, size_t&, size_t, bool, int, bool);
 template void runRepl<uint32_t>(std::vector<uint32_t>&, size_t&, size_t, bool, int, bool);
+template void runRepl<uint64_t>(std::vector<uint64_t>&, size_t&, size_t, bool, int, bool);


### PR DESCRIPTION
## Summary
- allow choosing 64-bit cell width with `--cw 64`
- instantiate REPL/VM templates for `uint64_t`
- fall back to scalar logic for SIMD scans when operating on 64-bit cells
- fix CMake coverage block nesting

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest --test-dir .`


------
https://chatgpt.com/codex/tasks/task_e_689a319f21348331929ecd3b8f428260